### PR TITLE
change the hyperlink from GitHub to Secure-Texts

### DIFF
--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -11,7 +11,7 @@ export default function Home({handleDecodeEl,setPage}) {
             </Head>
             <main>
                 <h1 className="title">
-                    Welcome to <a href="https://github.com/tushartiwari7/secure-texts">Secure Texts!</a>
+                    Welcome to <a href="https://secure-texts.vercel.app">Secure Texts!</a>
                 </h1>
                 <p className="description">
                     Get started by converting your text to cipher text using <code> Cryptographic Algorithms</code>
@@ -124,7 +124,6 @@ export default function Home({handleDecodeEl,setPage}) {
                 .description,{
                 text-align: center;
                 }
-
                 .description {
                 line-height: 1.5;
                 font-size: 1.5rem;
@@ -153,7 +152,6 @@ export default function Home({handleDecodeEl,setPage}) {
                 margin-top: 3rem;
                 transform: translateX(-14vw);
                 }
-
                 .card {
                 margin: 1rem;
                 flex-basis: 45%;


### PR DESCRIPTION
I think the secure-text hyper link should refer to the site itself and not the source code of the GitHub.